### PR TITLE
#22: Fix typos in 'trusty.yaml'

### DIFF
--- a/hiera/baseline/trusty64.yaml
+++ b/hiera/baseline/trusty64.yaml
@@ -22,5 +22,5 @@ cis_4_1_17: true
 cis_4_1_18: true
 cis_4_2_1_1: true
 cis_4_2_1_2: true
-cis_4_2_1_4 = false
-cis_4_2_1_5 = false
+cis_4_2_1_4: false
+cis_4_2_1_5: false


### PR DESCRIPTION
Resolves #22.