### PR TITLE
#40: Fix 'service' typo in 'auditd_rules.pp' (trusty64)

### DIFF
--- a/manifests/trusty64/auditd_rules.pp
+++ b/manifests/trusty64/auditd_rules.pp
@@ -42,7 +42,7 @@ class cis::trusty64::auditd_rules {
   }
 
   ## ensure auditd running
-  service { 'start-auditd':
+  service { 'auditd':
     ensure => true,
     enable => true,
   }


### PR DESCRIPTION
Resolves #40.