### PR TITLE
#130: cis_trusty64.yaml, fix key typo

### DIFF
--- a/hiera/baseline/cis_trusty64.yaml
+++ b/hiera/baseline/cis_trusty64.yaml
@@ -23,7 +23,7 @@ trusty64:
         cis_2_1_3: true
         cis_2_1_4: true
         cis_2_1_5: true
-        cis_2.1.10: true
+        cis_2_1_10: true
         cis_4_1_2: true
         cis_4_1_4: true
         cis_4_1_5: true


### PR DESCRIPTION
Resolves #130.